### PR TITLE
Dev/update tagline

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,10 +9,10 @@ url: "http://porphyrin.github.io"
 # Author Settings
 author: Olivia Warren
 author-img: ow_headshot.jpg
-about-author:
-- Data Scientist
-- Ex-Management Consultant
-- Biotech Nerd
+about-author: |
+  Data Scientist
+  Ex-Management Consultant
+  Biotech Nerd
 github: porphyrin
 linkedin: olivia-warren
 


### PR DESCRIPTION
Third try's the charm; add multi-line spacing to the author-info section.